### PR TITLE
feat: add 10-second delay before disconnecting from Wi-Fi network

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This is a Proof of Concept (POC) project for connecting to a Wi-Fi network programmatically.
 
-# Setup
-Before running the project, you need to configure the Wi-Fi network details by adding them to the local.properties file in the project root directory.
+## Setup
+Before running the project, you need to configure the Wi-Fi network details by adding them to the `local.properties` file in the project root directory.
 
 **Required Properties:**
 
@@ -38,7 +38,7 @@ If your app needs to connect to Wi-Fi networks, use the following alternative me
 
 source: https://developer.android.com/about/versions/10/privacy/changes#configure-wifi
 
-## Using CTS Verifier
+## CTS Verifier
 
 The Android Compatibility Test Suite Verifier (CTS Verifier) supplements the Compatibility Test Suite (CTS). While CTS checks APIs and functions that can be automated, CTS Verifier provides tests for APIs and functions that can't be tested on a stationary device without manual input or positioning, such as audio quality, touchscreen, accelerometer, and camera.
 

--- a/app/src/main/java/br/org/cesar/wificonnect/ui/screens/network/NetworkRequestUiState.kt
+++ b/app/src/main/java/br/org/cesar/wificonnect/ui/screens/network/NetworkRequestUiState.kt
@@ -9,7 +9,7 @@ data class NetworkRequestUiState(
     val wifiSsid: String? = null,
     val wifiPsk: String? = null,
     val isWifiEnabled: Boolean = false,
-    val requestDuration: Long? = null,
+    val requestDurations: List<Long?> = listOf(),
     val useCaseListener: UseCaseListener? = null,
     val listenerMessage: String = "",
     val useCaseStatus: UseCaseStatus = UseCaseStatus.NOT_EXECUTED,
@@ -18,8 +18,14 @@ data class NetworkRequestUiState(
 ) {
     fun getFormattedRequestDuration(): String {
         val formatter = DecimalFormat("#.###")
-        return requestDuration?.let {
-            "Duration: ${formatter.format(it)} ms"
-        } ?: ""
+        formatter.groupingSize = 3
+        formatter.isGroupingUsed = true
+
+        if (requestDurations.size > 1) {
+            return "1st: ${formatter.format(requestDurations[0])} ms;\t" +
+                    "2nd: ${formatter.format(requestDurations[1])} ms"
+        }
+
+        return ""
     }
 }

--- a/app/src/main/java/br/org/cesar/wificonnect/ui/screens/network/NetworkRequestViewModel.kt
+++ b/app/src/main/java/br/org/cesar/wificonnect/ui/screens/network/NetworkRequestViewModel.kt
@@ -10,6 +10,7 @@ import br.org.cesar.wificonnect.domain.usecase.UseCaseListener
 import br.org.cesar.wificonnect.domain.usecase.UseCaseStatus
 import br.org.cesar.wificonnect.domain.usecase.network.NetworkRequestUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -103,6 +104,8 @@ class NetworkRequestViewModel @Inject constructor(
 
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     private fun performWifiRequest(ssid: String?, psk: String?, listener: UseCaseListener?) {
+        updateState(useCaseStatus = UseCaseStatus.NOT_EXECUTED)
+
         if (!ssid.isNullOrEmpty() and !psk.isNullOrEmpty()) {
             viewModelScope.launch(dispatcherProvider.io) {
                 val requestDuration =
@@ -112,6 +115,7 @@ class NetworkRequestViewModel @Inject constructor(
                     requestDuration = requestDuration
                 )
 
+                delay(10000)
                 mNetworkRequestUseCase.unregisterNetworkCallback()
             }
         }


### PR DESCRIPTION
This PR adds a 10-second delay before disconnecting from the connected Wi-Fi network.
The delay ensures that any ongoing processes relying on the active connection can complete before termination.